### PR TITLE
Give different tag for arm/aarch64 binaries

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -100,7 +100,7 @@ jobs:
         git -C kmake_bin commit -a -m "Update Linux ARM binary to $GITHUB_SHA."
     - name: Tag binary
       if: steps.commit.outcome == 'success'
-      run: git -C kmake_bin tag linux_$GITHUB_SHA
+      run: git -C kmake_bin tag linuxarm_$GITHUB_SHA
     - name: Push binary
       id: push1
       if: steps.commit.outcome == 'success'
@@ -153,7 +153,7 @@ jobs:
         git -C kmake_bin commit -a -m "Update Linux ARM64 binary to $GITHUB_SHA."
     - name: Tag binary
       if: steps.commit.outcome == 'success'
-      run: git -C kmake_bin tag linux_$GITHUB_SHA
+      run: git -C kmake_bin tag linuxaarch64_$GITHUB_SHA
     - name: Push binary
       id: push1
       if: steps.commit.outcome == 'success'


### PR DESCRIPTION
Of course I forgot to rename the tag names as well. This is hopefully the last PR related to getting ARM binaries into kmake.

Sorry