### PR TITLE
Add feature to pass path to kmake source directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@ premake and cmake.
 It is an extended fork of Node.js so it provides the speed of V8 and all of the
 Node.js-API to kmake-build-scripts.
 
+For when you are only changing TypeScript and/or JavaScript files without also doing changes to the native side, clone this repo and with your normal kmake binary do:
 
-For when you are only changing TypeScript and/or JavaScript files to create a build that pulls them in at runtime, build with the following command:
+`kmake --dev absolute/path/to/kmake_repo`
+
+For when you are changing TypeScript and/or JavaScript files to create a node build that pulls them in at runtime, build with the following command:
 
 Windows: `vcbuild.bat openssl-no-asm without-intl node-builtin-modules-path %cd%`
 

--- a/src/node.h
+++ b/src/node.h
@@ -107,6 +107,8 @@
 # endif
 #endif
 
+extern char* g_kmake_dev_path;
+
 // Forward-declare libuv loop
 struct uv_loop_s;
 

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -41,7 +41,7 @@ static void CheckForDev(int* argc, char** argv) {
       int r = node::ReadFileSync(&temp,test_path);
       if (r != 0) {
         g_kmake_dev_path = NULL;
-        fprintf(stderr,"[ERROR] Failed to set the --dev path, the path specified isn't a kmake repo. Binary kmake source will be used.");
+        fprintf(stderr,"[ERROR] Failed to set the --dev path, the path specified isn't a kmake repo.Kmake source in binary will be used.");
       }
       i++;
       out_argc -= 2;

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -22,6 +22,38 @@
 #include "node.h"
 #include <cstdio>
 
+#include "util.h" // Needed for node::ReadFileSync
+
+/*
+* This function will parse argv and if it finds --dev will take the next argument
+* and set g_make_dev_path to that value. This function will change the value of argv and argc.
+*/
+static void CheckForDev(int* argc, char** argv) {
+  char* temp_argv[64] = {0};
+  int out_argc = *argc;
+  int minus = 0;
+  for (int i = 0; i < *argc; ++i) {
+    if (strcmp("--dev", argv[i]) == 0 && *argc > i +1) {
+      g_kmake_dev_path = argv[i+1];
+      char test_path[260];
+      snprintf(test_path,260,"%s/lib/kmake/init.js",g_kmake_dev_path);
+      std::string temp;
+      int r = node::ReadFileSync(&temp,test_path);
+      if (r != 0) {
+        g_kmake_dev_path = NULL;
+        fprintf(stderr,"[ERROR] Failed to set the --dev path, the path specified isn't a kmake repo. Binary kmake source will be used.");
+      }
+      i++;
+      out_argc -= 2;
+      minus = -2;
+      continue;
+    }
+    temp_argv[i+minus] = argv[i];
+  }
+  temp_argv[out_argc] = nullptr;
+  *argc = out_argc;
+  memcpy(argv,temp_argv,sizeof(char*) * (*argc +1));
+}
 #ifdef _WIN32
 #include <windows.h>
 #include <VersionHelpers.h>
@@ -83,6 +115,7 @@ int wmain(int argc, wchar_t* wargv[]) {
     }
   }
   argv[argc] = nullptr;
+  CheckForDev(&argc,argv);
   // Now that conversion is done, we can finally start.
   return node::Start(argc, argv);
 }
@@ -124,6 +157,7 @@ int main(int argc, char* argv[]) {
   // calls elsewhere in the program (e.g., any logging from V8.)
   setvbuf(stdout, nullptr, _IONBF, 0);
   setvbuf(stderr, nullptr, _IONBF, 0);
+  CheckForDev(&argc,argv);
   return node::Start(argc, argv);
 }
 #endif


### PR DESCRIPTION
This implements what we were talking about.
```
3:23 PM]mundusnine: you know what would be faster, adding a flag to kmake to specify the path of the built-ins, that way no need to have people compile nodejs just  for modifying ts files. I would be up to add it to the native part if you agree
[3:39 PM]RobDangerous: And if you figure out how to switch to not using built-ins with a runtime-flag - sure, go ahead.
```
This will enable people who just want to modify the kmake typescript files to specify the path to their cloned repo of kmake and the pre-built binary will use the path specified. You can use kmake as is otherwise.

The flag in question is: `--dev` like so: `kmake --dev path/to/kmake_repository --from path/to/project/with/kfile`